### PR TITLE
Fixing comparison of Double values

### DIFF
--- a/screener/src/com/blogspot/pdrobushevich/screener/screener/data/CompanyComparator.java
+++ b/screener/src/com/blogspot/pdrobushevich/screener/screener/data/CompanyComparator.java
@@ -19,9 +19,9 @@ public class CompanyComparator implements Comparator<Company> {
         } else if ("Symbol".equalsIgnoreCase(sortedColumn)) {
             return company1.getSymbol().compareTo(company2.getSymbol()) * sortDirection;
         } else if ("Market cap.".equalsIgnoreCase(sortedColumn)) {
-            return (int) (company1.getMktCap() - company2.getMktCap()) * sortDirection;
+            return Double.compare(company1.getMktCap(), company2.getMktCap()) * sortDirection;
         } else if ("Price".equalsIgnoreCase(sortedColumn)) {
-            return (int) (company1.getPrice() - company2.getPrice()) * sortDirection;
+            return Double.compare(company1.getPrice(), company2.getPrice()) * sortDirection;
         }
         return 0;
     }


### PR DESCRIPTION
`(int)(double1 - double2)` is not the right way to write a comparator for doubles. It fails when the absolute difference between `double1` and `double2` is less than 1. [Double.compare(double, double)](http://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#compare%28double, double%29) is a better choice.
